### PR TITLE
Fix info not copying to new upload.

### DIFF
--- a/app/Imports/VoucherImport.php
+++ b/app/Imports/VoucherImport.php
@@ -33,7 +33,7 @@ class VoucherImport implements ToModel, WithHeadingRow, WithEvents, WithBatchIns
     {
         if ($this->rowShouldNotBeIgnored($row['ditem'])) {
             $print_complete = $row['cmpdte'];
-            $existing = Order::where('order_number', $row['ordnr'])->where('voucher', $row['orvch'])->first();
+            $existing = Order::latest('report_created')->where('order_number', $row['ordnr'])->where('voucher', $row['orvch'])->first();
             $art_complete = optional($existing)->art_complete;
 
             return new Order([


### PR DESCRIPTION
- Fix info not copying to new upload.
  - Existing voucher was being set to the first voucher found instead of the latest (which had the necessary info for copying). So now we get the latest, according to 'report_created' which will have the correct, latest info.