### PR TITLE
Hack to make modal form submission not leave stale data behind.

### DIFF
--- a/resources/js/Modals/NewVoucherModal.vue
+++ b/resources/js/Modals/NewVoucherModal.vue
@@ -94,7 +94,7 @@ export default {
         submit () {
             this.sending = true;
             this.submitted = true;
-            this.$inertia.post(this.route('orders.add'), this.form, { replace: false, preserveScroll: false, preserveState: false }).then(() => {
+            this.$inertia.post(this.route('orders.add'), this.form, { replace: false, preserveScroll: false, preserveState: true }).then(() => {
                 this.sending = false;
             });
         },

--- a/resources/js/Partials/Reports/IndividualReport.vue
+++ b/resources/js/Partials/Reports/IndividualReport.vue
@@ -128,6 +128,14 @@ export default {
             return ! this.notEmpty;
         },
     },
+    watch: {
+        data: {
+            handler (value) {
+               this.setInitialInfo();
+            },
+            deep: true,
+        },
+    },
     methods: {
         showActionModal (index, item) {
             if (! this.$page.auth.user.is_admin) return;

--- a/resources/js/mixins/WatchesForErrors.js
+++ b/resources/js/mixins/WatchesForErrors.js
@@ -17,8 +17,8 @@ export default {
                 }
                 if (! this.$collection(newErrors).has(this.errorBag) && this.form && this.submitted) {
                     this.submitted = false;
-
-                    return this.resetForm();
+                    this.resetForm();
+                    this.$inertia.replace(window.location.pathname, { method: 'get', data: {}, preserveScroll: false, preserveState: false });
                 }
             },
             deep: true,


### PR DESCRIPTION
Currently, if you open a modal from a page to which you'll be returned on a successful form submit from the modal, stale data will remain because you can't tell inertia to replace the data. If you do, then in case of form errors, the errors won't come through. There is a possible fix in the works on the inertia repo, in the meantime, we'll just force a get request on the page if there are no errors present.