### PR TITLE
Don't throw exception when route doesn't have breadcrumbs.

### DIFF
--- a/config/breadcrumbs.php
+++ b/config/breadcrumbs.php
@@ -52,7 +52,7 @@ return [
     'unnamed-route-exception' => true,
 
     // When route-bound breadcrumbs are used and the matching breadcrumb doesn't exist (InvalidBreadcrumbException)
-    'missing-route-bound-breadcrumb-exception' => true,
+    'missing-route-bound-breadcrumb-exception' => false,
 
     // When a named breadcrumb is used but doesn't exist (InvalidBreadcrumbException)
     'invalid-named-breadcrumb-exception' => true,


### PR DESCRIPTION
- Don't throw exception when route doesn't have breadcrumbs.